### PR TITLE
[Feature] Add devcontainer and fix deprecated output

### DIFF
--- a/.devcontainer/.devcontainer.json
+++ b/.devcontainer/.devcontainer.json
@@ -1,0 +1,49 @@
+{
+	"name": "web-app-pattern-java",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "jammy"
+		}
+	},
+	"remoteUser": "vscode",
+	"containerEnv": {
+		"M2": "/home/vscode" // required because the java feature is not setting this correctly
+	},
+	"features": {
+		// https://containers.dev/features
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/azure-cli:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "17",
+			"installMaven": "true",
+			"installGradle": "false"
+			
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/terraform:1": {},
+		"ghcr.io/azure/azure-dev/azd:latest": {}
+	},
+	//"forwardPorts": [ ],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				// Extension Pack for Java; includes language support, debugging, maven.
+				"vscjava.vscode-java-pack",
+				// Spring Boot Extension Pack
+				"vmware.vscode-boot-dev-pack",
+				// YAML language support
+				"redhat.vscode-yaml",
+				// Terraform
+				"ms-azuretools.vscode-azureterraform"
+			]
+		}
+	},
+	"hostRequirements": {
+		"cpus": 2
+	}
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+ARG VARIANT="jammy"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y xdg-utils postgresql-client jq \
+    && apt-get install -y protobuf-compiler \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/infra/dev/shared/terraform/modules/app-service/outputs.tf
+++ b/infra/dev/shared/terraform/modules/app-service/outputs.tf
@@ -19,7 +19,7 @@ output "application_name" {
 }
 
 output "application_registration_id" {
-  value = azuread_application.app_registration.application_id
+  value = azuread_application.app_registration.client_id
   description = "The id of application registration  (also called Client ID)."
 }
 


### PR DESCRIPTION
- Added devcontainer 
- Updated Azure AD Application ID output from application_id to client_id since application_id has been deprecated