### PR TITLE
[Feature] Add Service Bus, Container Apps and Container Registry Terraform modules

### DIFF
--- a/infra/dev/shared/terraform/modules/aca/main.tf
+++ b/infra/dev/shared/terraform/modules/aca/main.tf
@@ -1,0 +1,92 @@
+terraform {
+  required_providers {
+    azurecaf = {
+      source  = "aztfmod/azurecaf"
+      version = "1.2.26"
+    }
+  }
+}
+
+resource "azurerm_container_app_environment" "container_app_environment" {
+  name                       = var.application_name
+  location                   = var.location
+  resource_group_name        = var.resource_group
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+}
+
+resource "azurerm_container_app" "container_app" {
+  name                         = "email-processor"
+  container_app_environment_id = azurerm_container_app_environment.container_app_environment.id
+  resource_group_name          = var.resource_group
+  revision_mode                = "Single"
+
+  tags = {
+    "environment"      = var.environment
+    "application-name" = var.application_name
+    "azd-service-name" = "email-processor"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template.0.container["image"]
+    ]
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      var.container_registry_user_assigned_identity_id
+    ]
+  }
+
+  registry {
+    server   = var.acr_login_server
+    identity = var.container_registry_user_assigned_identity_id
+  }
+
+  secret {
+    name  = "azure-servicebus-connection-string"
+    value = var.servicebus_namespace_primary_connection_string
+  }
+
+  template {
+    container {
+      name = "email-processor-app"
+
+      // A container image is required to deploy the ACA resource.
+      // Since the rendering service image is not available yet,
+      // we use a placeholder image for now.
+      image  = "mcr.microsoft.com/cbl-mariner/busybox:2.0"
+      cpu    = 1.0
+      memory = "2.0Gi"
+      env {
+        name  = "AZURE_SERVICEBUS_NAMESPACE"
+        value = var.servicebus_namespace
+      }
+      env {
+        name  = "AZURE_SERVICEBUS_EMAIL_REQUEST_QUEUE_NAME"
+        value = var.email_request_queue_name
+      }
+      env {
+        name  = "AZURE_SERVICEBUS_EMAIL_RESPONSE_QUEUE_NAME"
+        value = var.email_response_queue_name
+      }
+    }
+    max_replicas = 10
+    min_replicas = 1
+
+    custom_scale_rule {
+      name             = "service-bus-queue-length-rule"
+      custom_rule_type = "azure-servicebus"
+      metadata = {
+        messageCount = 10
+        namespace    = var.servicebus_namespace
+        queueName    = var.email_request_queue_name
+      }
+      authentication {
+        secret_name       = "azure-servicebus-connection-string"
+        trigger_parameter = "connection"
+      }
+    }
+  }
+}

--- a/infra/dev/shared/terraform/modules/aca/main.tf
+++ b/infra/dev/shared/terraform/modules/aca/main.tf
@@ -12,6 +12,14 @@ resource "azurerm_container_app_environment" "container_app_environment" {
   location                   = var.location
   resource_group_name        = var.resource_group
   log_analytics_workspace_id = var.log_analytics_workspace_id
+  zone_redundancy_enabled    = var.environment == "prod" ? true : false
+
+  internal_load_balancer_enabled = var.isNetworkIsolated
+
+  workload_profile {
+    name                  = "Consumption"
+    workload_profile_type = "Consumption"
+  }
 }
 
 resource "azurerm_container_app" "container_app" {
@@ -19,7 +27,15 @@ resource "azurerm_container_app" "container_app" {
   container_app_environment_id = azurerm_container_app_environment.container_app_environment.id
   resource_group_name          = var.resource_group
   revision_mode                = "Single"
-
+  workload_profile_name        = "Consumption"
+  ingress {
+    allow_insecure_connections = false
+    external_enabled = true
+    target_port = 80
+    traffic_weight {
+      percentage = 100
+    }
+  }
   tags = {
     "environment"      = var.environment
     "application-name" = var.application_name

--- a/infra/dev/shared/terraform/modules/aca/main.tf
+++ b/infra/dev/shared/terraform/modules/aca/main.tf
@@ -7,6 +7,8 @@ terraform {
   }
 }
 
+# Create Azure Container Apps Environment in Dev
+
 resource "azurerm_container_app_environment" "container_app_environment_dev" {
   count                      = var.environment == "dev" ? 1 : 0
   name                       = var.application_name
@@ -19,6 +21,8 @@ resource "azurerm_container_app_environment" "container_app_environment_dev" {
     workload_profile_type = "Consumption"
   }
 }
+
+# Create Azure Container Apps Environment in Prod
 
 resource "azurerm_container_app_environment" "container_app_environment_prod" {
   count                      = var.environment == "prod" ? 1 : 0
@@ -36,6 +40,8 @@ resource "azurerm_container_app_environment" "container_app_environment_prod" {
     workload_profile_type = "Consumption"
   }
 }
+
+# Create Azure Container App in the specified environment
 
 resource "azurerm_container_app" "container_app" {
   name                         = "email-processor"
@@ -123,9 +129,8 @@ resource "azurerm_container_app" "container_app" {
   }
 }
 
-# Azure Private DNS provides a reliable, secure DNS service to manage and
-# resolve domain names in a virtual network without the need to add a custom DNS solution
-# https://docs.microsoft.com/azure/dns/private-dns-privatednszone
+# Create Private DNS Zone for Azure Container Apps in Prod if internal load balancer is enabled
+
 resource "azurerm_private_dns_zone" "dns_for_aca" {
   count               = var.environment == "prod" && var.isNetworkIsolated ? 1 : 0
   name                = var.environment == "prod" ? azurerm_container_app_environment.container_app_environment_prod[0].default_domain : azurerm_container_app_environment.container_app_environment_dev[0].default_domain

--- a/infra/dev/shared/terraform/modules/aca/outputs.tf
+++ b/infra/dev/shared/terraform/modules/aca/outputs.tf
@@ -1,0 +1,3 @@
+output "identity_principal_id" {
+  value = azurerm_container_app.container_app.identity[0].principal_id
+}

--- a/infra/dev/shared/terraform/modules/aca/variables.tf
+++ b/infra/dev/shared/terraform/modules/aca/variables.tf
@@ -53,3 +53,8 @@ variable "email_response_queue_name" {
   type        = string
   description = "The name of the email response queue"
 }
+
+variable "isNetworkIsolated" {
+  type        = bool
+  description = "Indicates if the container app should be network isolated"
+}

--- a/infra/dev/shared/terraform/modules/aca/variables.tf
+++ b/infra/dev/shared/terraform/modules/aca/variables.tf
@@ -1,0 +1,55 @@
+variable "resource_group" {
+  type        = string
+  description = "The resource group"
+}
+
+variable "environment" {
+  type        = string
+  description = "The environment (dev, test, prod...)"
+  default     = "dev"
+}
+
+variable "location" {
+  type        = string
+  description = "The Azure region where all resources in this example should be created"
+}
+
+variable "application_name" {
+  type        = string
+  description = "The name of your application"
+}
+
+variable "log_analytics_workspace_id" {
+  type        = string
+  description = "The ID of the Log Analytics workspace"
+}
+
+variable "acr_login_server" {
+  type        = string
+  description = "The login server of the Azure Container Registry"
+}
+
+variable "container_registry_user_assigned_identity_id" {
+  type        = string
+  description = "The ID of the user-assigned identity for the Azure Container Registry"
+}
+
+variable "servicebus_namespace_primary_connection_string" {
+  type        = string
+  description = "The primary connection string of the Azure Service Bus namespace"
+}
+
+variable "servicebus_namespace" {
+  type        = string
+  description = "The name of the Azure Service Bus namespace"
+}
+
+variable "email_request_queue_name" {
+  type        = string
+  description = "The name of the email request queue"
+}
+
+variable "email_response_queue_name" {
+  type        = string
+  description = "The name of the email response queue"
+}

--- a/infra/dev/shared/terraform/modules/aca/variables.tf
+++ b/infra/dev/shared/terraform/modules/aca/variables.tf
@@ -57,4 +57,17 @@ variable "email_response_queue_name" {
 variable "isNetworkIsolated" {
   type        = bool
   description = "Indicates if the container app should be network isolated"
+  default     = false
+}
+
+variable "infrastructure_subnet_id" {
+  type        = string
+  description = "The ID of the subnet where the infrastructure resources should be created"
+  default     = null
+}
+
+variable "spoke_vnet_id" {
+  type        = string
+  description = "The ID of the spoke VNET"
+  default     = null
 }

--- a/infra/dev/shared/terraform/modules/acr/main.tf
+++ b/infra/dev/shared/terraform/modules/acr/main.tf
@@ -34,7 +34,7 @@ resource "azurerm_container_registry" "acr" {
       default_action = network_rule_set.value.default_action
 
       dynamic "ip_rule" {
-        for_each = network_rule_set.value.ip_rule
+        for_each = network_rule_set.value.ip_rules
         content {
           action   = ip_rule.value.action
           ip_range = ip_rule.value.ip_range
@@ -84,7 +84,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "virtual_network_link_a
   count                 = var.environment == "prod" ? 1 : 0
   name                  = "privatelink.azurecr.io"
   private_dns_zone_name = azurerm_private_dns_zone.dns_for_acr[0].name
-  virtual_network_id    = var.private_endpoint_vnet_id
+  virtual_network_id    = var.spoke_vnet_id
   resource_group_name   = var.resource_group
 }
 

--- a/infra/dev/shared/terraform/modules/acr/main.tf
+++ b/infra/dev/shared/terraform/modules/acr/main.tf
@@ -1,0 +1,105 @@
+terraform {
+  required_providers {
+    azurecaf = {
+      source  = "aztfmod/azurecaf"
+      version = "1.2.26"
+    }
+  }
+}
+
+data "azuread_client_config" "current" {}
+
+resource "azurerm_container_registry" "acr" {
+  name                = var.application_name
+  resource_group_name = var.resource_group
+  location            = var.location
+
+  sku = "Premium"
+
+  admin_enabled                 = false
+  public_network_access_enabled = var.environment == "prod" ? false : true
+  network_rule_bypass_option    = "AzureServices"
+
+  dynamic "georeplications" {
+    for_each = var.georeplications
+    content {
+      location = georeplications.value.location
+    }
+    
+  }
+  network_rule_set {
+    default_action = var.network_rules.default_action
+
+    dynamic "ip_rule" {
+      for_each = var.network_rules.ip_rules != null ? var.network_rules.ip_rules : []
+      content {
+        action   = ip_rule.value.action
+        ip_range = ip_rule.value.ip_range
+      }
+    }
+  }
+}
+
+resource "azurerm_role_assignment" "container_app_acr_pull" {
+  principal_id                     = var.aca_identity_principal_id
+  role_definition_name             = "AcrPull"
+  scope                            = azurerm_container_registry.acr.id
+}
+
+resource "azurerm_user_assigned_identity" "container_registry_user_assigned_identity" {
+  name                = "ContainerRegistryUserAssignedIdentity"
+  resource_group_name = var.resource_group
+  location            = var.location
+}
+
+resource "azurerm_role_assignment" "container_registry_user_assigned_identity_acr_pull" {
+  scope                = azurerm_container_registry.acr.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.container_registry_user_assigned_identity.principal_id
+}
+
+
+# For demo purposes, allow current user access to the container registry
+# Note: when running as a service principal, this is also needed
+resource azurerm_role_assignment acr_contributor_user_role_assignement {
+  scope                 = azurerm_container_registry.acr.id
+  role_definition_name  = "Contributor"
+  principal_id          = data.azuread_client_config.current.object_id
+}
+
+# Azure Private DNS provides a reliable, secure DNS service to manage and
+# resolve domain names in a virtual network without the need to add a custom DNS solution
+# https://docs.microsoft.com/azure/dns/private-dns-privatednszone
+resource "azurerm_private_dns_zone" "dns_for_acr" {
+  count               = var.environment == "prod" ? 1 : 0
+  name                = "privatelink.azurecr.io"
+  resource_group_name = var.resource_group
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "virtual_network_link_acr" {
+  count                 = var.environment == "prod" ? 1 : 0
+  name                  = "privatelink.azurecr.io"
+  private_dns_zone_name = azurerm_private_dns_zone.dns_for_acr[0].name
+  virtual_network_id    = var.private_endpoint_vnet_id
+  resource_group_name   = var.resource_group
+}
+
+resource "azurerm_private_endpoint" "acr_pe" {
+  count               = var.environment == "prod" ? 1 : 0
+  name                = "private-endpoint-acr"
+  location            = var.location
+  resource_group_name = var.resource_group
+  subnet_id           = var.private_endpoint_subnet_id
+
+   private_dns_zone_group {
+    name                 = "privatednsacrzonegroup"
+    private_dns_zone_ids = [azurerm_private_dns_zone.dns_for_acr[0].id]
+  }
+
+  private_service_connection {
+    name                           = "peconnection-acr"
+    private_connection_resource_id = azurerm_container_registry.acr.id
+    is_manual_connection           = false
+    subresource_names              = ["registry"]
+  }
+}

--- a/infra/dev/shared/terraform/modules/acr/main.tf
+++ b/infra/dev/shared/terraform/modules/acr/main.tf
@@ -9,6 +9,8 @@ terraform {
 
 data "azuread_client_config" "current" {}
 
+# Create Azure Container Registry
+
 resource "azurerm_container_registry" "acr" {
   name                = var.application_name
   resource_group_name = var.resource_group
@@ -44,6 +46,8 @@ resource "azurerm_container_registry" "acr" {
   }
 }
 
+# Create role assignments
+
 resource "azurerm_role_assignment" "container_app_acr_pull" {
   principal_id         = var.aca_identity_principal_id
   role_definition_name = "AcrPull"
@@ -71,9 +75,8 @@ resource "azurerm_role_assignment" "acr_contributor_user_role_assignement" {
   principal_id         = data.azuread_client_config.current.object_id
 }
 
-# Azure Private DNS provides a reliable, secure DNS service to manage and
-# resolve domain names in a virtual network without the need to add a custom DNS solution
-# https://docs.microsoft.com/azure/dns/private-dns-privatednszone
+# Create Private DNS Zone and Endpoint for ACR
+
 resource "azurerm_private_dns_zone" "dns_for_acr" {
   count               = var.environment == "prod" ? 1 : 0
   name                = "privatelink.azurecr.io"

--- a/infra/dev/shared/terraform/modules/acr/outputs.tf
+++ b/infra/dev/shared/terraform/modules/acr/outputs.tf
@@ -10,6 +10,6 @@ output "acr_login_server" {
 
 output "container_registry_user_assigned_identity_id" {
   value       = azurerm_user_assigned_identity.container_registry_user_assigned_identity.id
-  description = "The Azure User Assigned Identity ID."
+  description = "The ACR User Assigned Identity ID."
 
 }

--- a/infra/dev/shared/terraform/modules/acr/outputs.tf
+++ b/infra/dev/shared/terraform/modules/acr/outputs.tf
@@ -1,15 +1,15 @@
 output "acr_name" {
-  value = azurerm_container_registry.acr.name
+  value       = azurerm_container_registry.acr.name
   description = "The Azure Container Registry Name."
 }
 
 output "acr_login_server" {
-  value = azurerm_container_registry.acr.login_server
+  value       = azurerm_container_registry.acr.login_server
   description = "The Azure Container Registry Login Server."
 }
 
 output "container_registry_user_assigned_identity_id" {
-  value = azurerm_user_assigned_identity.container_registry_user_assigned_identity.id
+  value       = azurerm_user_assigned_identity.container_registry_user_assigned_identity.id
   description = "The Azure User Assigned Identity ID."
-  
+
 }

--- a/infra/dev/shared/terraform/modules/acr/outputs.tf
+++ b/infra/dev/shared/terraform/modules/acr/outputs.tf
@@ -1,0 +1,15 @@
+output "acr_name" {
+  value = azurerm_container_registry.acr.name
+  description = "The Azure Container Registry Name."
+}
+
+output "acr_login_server" {
+  value = azurerm_container_registry.acr.login_server
+  description = "The Azure Container Registry Login Server."
+}
+
+output "container_registry_user_assigned_identity_id" {
+  value = azurerm_user_assigned_identity.container_registry_user_assigned_identity.id
+  description = "The Azure User Assigned Identity ID."
+  
+}

--- a/infra/dev/shared/terraform/modules/acr/variables.tf
+++ b/infra/dev/shared/terraform/modules/acr/variables.tf
@@ -25,24 +25,24 @@ variable "aca_identity_principal_id" {
 }
 
 variable "network_rules" {
-  type = object({
+  type = list(object({
     default_action = string
     ip_rules = list(object({
       action   = string
-      ip_range = string
+      ip_range = list(string)
     }))
-  })
+  }))
 
-  default = {
+  default = [{
     default_action = "Allow"
-    ip_rules = []
-  }
+    ip_rules       = []
+  }]
 }
 
 variable "georeplications" {
   type = list(object({
     location = string
-  })) 
+  }))
   default = []
 }
 

--- a/infra/dev/shared/terraform/modules/acr/variables.tf
+++ b/infra/dev/shared/terraform/modules/acr/variables.tf
@@ -1,0 +1,57 @@
+variable "resource_group" {
+  type        = string
+  description = "The resource group"
+}
+
+variable "environment" {
+  type        = string
+  description = "The environment (dev, test, prod...)"
+  default     = "dev"
+}
+
+variable "location" {
+  type        = string
+  description = "The Azure region where all resources in this example should be created"
+}
+
+variable "application_name" {
+  type        = string
+  description = "The name of your application"
+}
+
+variable "aca_identity_principal_id" {
+  type        = string
+  description = "The principal id of the identity of the container app"
+}
+
+variable "network_rules" {
+  type = object({
+    default_action = string
+    ip_rules = list(object({
+      action   = string
+      ip_range = string
+    }))
+  })
+
+  default = {
+    default_action = "Allow"
+    ip_rules = []
+  }
+}
+
+variable "georeplications" {
+  type = list(object({
+    location = string
+  })) 
+  default = []
+}
+
+variable "private_endpoint_subnet_id" {
+  type        = string
+  description = "The ID of the subnet where the private endpoint should be created"
+}
+
+variable "private_endpoint_vnet_id" {
+  type        = string
+  description = "The ID of the VNet where the private endpoint should be created"
+}

--- a/infra/dev/shared/terraform/modules/acr/variables.tf
+++ b/infra/dev/shared/terraform/modules/acr/variables.tf
@@ -25,18 +25,15 @@ variable "aca_identity_principal_id" {
 }
 
 variable "network_rules" {
-  type = list(object({
-    default_action = string
-    ip_rules = list(object({
+  type = object({
+    default_action = optional(string)
+    ip_rules = optional(list(object({
       action   = string
-      ip_range = list(string)
-    }))
-  }))
+      ip_range = string
+    })), [])
+  })
 
-  default = [{
-    default_action = "Allow"
-    ip_rules       = []
-  }]
+  default = null
 }
 
 variable "georeplications" {
@@ -49,9 +46,11 @@ variable "georeplications" {
 variable "private_endpoint_subnet_id" {
   type        = string
   description = "The ID of the subnet where the private endpoint should be created"
+  default     = null
 }
 
-variable "private_endpoint_vnet_id" {
+variable "spoke_vnet_id" {
   type        = string
-  description = "The ID of the VNet where the private endpoint should be created"
+  description = "The ID of the Spoke VNET"
+  default     = null
 }

--- a/infra/dev/shared/terraform/modules/service-bus/main.tf
+++ b/infra/dev/shared/terraform/modules/service-bus/main.tf
@@ -19,9 +19,10 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   name                          = azurecaf_name.servicebus_namespace_name.result
   location                      = var.location
   resource_group_name           = var.resource_group
-  sku                           = "Standard"
+  sku                           = var.environment == "prod" ? "Premium" : "Standard"
   public_network_access_enabled = var.environment == "prod" ? false : true
-
+  capacity                      = var.environment == "prod" ? var.capacity : 0
+  premium_messaging_partitions  = var.environment == "prod" ? 1 : 0
   # Should be set to false, but we need it for Keda scaling rules
   # https://github.com/microsoft/azure-container-apps/issues/592
   local_auth_enabled = false
@@ -125,7 +126,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "virtual_network_link_s
   count                 = var.environment == "prod" ? 1 : 0
   name                  = "privatelink.servicebus.windows.net"
   private_dns_zone_name = azurerm_private_dns_zone.dns_for_service_bus[0].name
-  virtual_network_id    = var.private_endpoint_vnet_id
+  virtual_network_id    = var.spoke_vnet_id
   resource_group_name   = var.resource_group
 }
 

--- a/infra/dev/shared/terraform/modules/service-bus/main.tf
+++ b/infra/dev/shared/terraform/modules/service-bus/main.tf
@@ -15,6 +15,8 @@ resource "azurecaf_name" "servicebus_namespace_name" {
   suffixes      = [var.environment]
 }
 
+# Create Service Bus namespace
+
 resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   name                          = azurecaf_name.servicebus_namespace_name.result
   location                      = var.location
@@ -35,7 +37,7 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   }
 }
 
-######
+# Create Email Request queue
 
 resource "azurecaf_name" "servicebus_email_request_queue_name" {
   name          = "email-request-queue"
@@ -55,7 +57,7 @@ resource "azurerm_servicebus_queue" "email_request_queue" {
   default_message_ttl   = "P14D"
 }
 
-########################
+# Create Email Response queue
 
 resource "azurecaf_name" "servicebus_email_response_queue_name" {
   name          = "email-response-queue"
@@ -76,8 +78,7 @@ resource "azurerm_servicebus_queue" "email_response_queue" {
 }
 
 
-#######
-
+# Create role assignments
 
 resource "azurerm_role_assignment" "role_servicebus_data_owner" {
   scope                = azurerm_servicebus_namespace.servicebus_namespace.id
@@ -113,9 +114,8 @@ resource "azurerm_role_assignment" "role_servicebus_data_receiver_email_processo
   principal_id         = var.container_app_identity_principal_id
 }
 
-# Azure Private DNS provides a reliable, secure DNS service to manage and
-# resolve domain names in a virtual network without the need to add a custom DNS solution
-# https://docs.microsoft.com/azure/dns/private-dns-privatednszone
+# Create Private DNS Zone and Endpoint for Service Bus
+
 resource "azurerm_private_dns_zone" "dns_for_service_bus" {
   count               = var.environment == "prod" ? 1 : 0
   name                = "privatelink.servicebus.windows.net"

--- a/infra/dev/shared/terraform/modules/service-bus/main.tf
+++ b/infra/dev/shared/terraform/modules/service-bus/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   # https://github.com/microsoft/azure-container-apps/issues/592
   local_auth_enabled = false
 
-  zone_redundant = false
+  zone_redundant = var.environment == "prod" ? true : false
 
   tags = {
     "environment"      = var.environment

--- a/infra/dev/shared/terraform/modules/service-bus/main.tf
+++ b/infra/dev/shared/terraform/modules/service-bus/main.tf
@@ -1,0 +1,150 @@
+terraform {
+  required_providers {
+    azurecaf = {
+      source  = "aztfmod/azurecaf"
+      version = "1.2.26"
+    }
+  }
+}
+
+data "azuread_client_config" "current" {}
+
+resource "azurecaf_name" "servicebus_namespace_name" {
+  name          = var.application_name
+  resource_type = "azurerm_servicebus_namespace"
+  suffixes      = [var.environment]
+}
+
+resource "azurerm_servicebus_namespace" "servicebus_namespace" {
+  name                          = azurecaf_name.servicebus_namespace_name.result
+  location                      = var.location
+  resource_group_name           = var.resource_group
+  sku                           = "Standard"
+  public_network_access_enabled = var.environment == "prod" ? false : true
+
+  # Should be set to false, but we need it for Keda scaling rules
+  # https://github.com/microsoft/azure-container-apps/issues/592
+  local_auth_enabled = false
+
+  zone_redundant = false
+
+  tags = {
+    "environment"      = var.environment
+    "application-name" = var.application_name
+  }
+}
+
+######
+
+resource "azurecaf_name" "servicebus_email_request_queue_name" {
+  name          = "email-request-queue"
+  resource_type = "azurerm_servicebus_queue"
+  suffixes      = [var.environment]
+}
+
+resource "azurerm_servicebus_queue" "email_request_queue" {
+  name         = azurecaf_name.servicebus_email_request_queue_name.result
+  namespace_id = azurerm_servicebus_namespace.servicebus_namespace.id
+
+  enable_partitioning   = false
+  max_delivery_count    = 10
+  lock_duration         = "PT30S"
+  max_size_in_megabytes = 1024
+  requires_session      = false
+  default_message_ttl   = "P14D"
+}
+
+########################
+
+resource "azurecaf_name" "servicebus_email_response_queue_name" {
+  name          = "email-response-queue"
+  resource_type = "azurerm_servicebus_queue"
+  suffixes      = [var.environment]
+}
+
+resource "azurerm_servicebus_queue" "email_response_queue" {
+  name         = azurecaf_name.servicebus_email_response_queue_name.result
+  namespace_id = azurerm_servicebus_namespace.servicebus_namespace.id
+
+  enable_partitioning   = false
+  max_delivery_count    = 10
+  lock_duration         = "PT30S"
+  max_size_in_megabytes = 1024
+  requires_session      = false
+  default_message_ttl   = "P14D"
+}
+
+
+#######
+
+
+resource "azurerm_role_assignment" "role_servicebus_data_owner" {
+  scope                = azurerm_servicebus_namespace.servicebus_namespace.id
+  role_definition_name = "Azure Service Bus Data Owner"
+  principal_id         = data.azuread_client_config.current.object_id
+}
+
+resource "azurerm_role_assignment" "role_servicebus_data_sender" {
+  scope                = azurerm_servicebus_namespace.servicebus_namespace.id
+  role_definition_name = "Azure Service Bus Data Sender"
+  principal_id         = var.web_application_principal_id
+}
+
+resource "azurerm_role_assignment" "role_servicebus_data_receiver" {
+  scope                = azurerm_servicebus_namespace.servicebus_namespace.id
+  role_definition_name = "Azure Service Bus Data Receiver"
+  principal_id         = var.web_application_principal_id
+}
+
+
+######
+
+
+resource "azurerm_role_assignment" "role_servicebus_data_sender_email_processor" {
+  scope                = azurerm_servicebus_namespace.servicebus_namespace.id
+  role_definition_name = "Azure Service Bus Data Sender"
+  principal_id         = var.container_app_identity_principal_id
+}
+
+resource "azurerm_role_assignment" "role_servicebus_data_receiver_email_processor" {
+  scope                = azurerm_servicebus_namespace.servicebus_namespace.id
+  role_definition_name = "Azure Service Bus Data Receiver"
+  principal_id         = var.container_app_identity_principal_id
+}
+
+# Azure Private DNS provides a reliable, secure DNS service to manage and
+# resolve domain names in a virtual network without the need to add a custom DNS solution
+# https://docs.microsoft.com/azure/dns/private-dns-privatednszone
+resource "azurerm_private_dns_zone" "dns_for_service_bus" {
+  count               = var.environment == "prod" ? 1 : 0
+  name                = "privatelink.servicebus.windows.net"
+  resource_group_name = var.resource_group
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "virtual_network_link_service_bus" {
+  count                 = var.environment == "prod" ? 1 : 0
+  name                  = "privatelink.servicebus.windows.net"
+  private_dns_zone_name = azurerm_private_dns_zone.dns_for_service_bus[0].name
+  virtual_network_id    = var.private_endpoint_vnet_id
+  resource_group_name   = var.resource_group
+}
+
+resource "azurerm_private_endpoint" "service_bus_pe" {
+  count               = var.environment == "prod" ? 1 : 0
+  name                = "private-endpoint-service-bus"
+  location            = var.location
+  resource_group_name = var.resource_group
+  subnet_id           = var.private_endpoint_subnet_id
+
+  private_dns_zone_group {
+    name                 = "privatednsservicebuszonegroup"
+    private_dns_zone_ids = [azurerm_private_dns_zone.dns_for_service_bus[0].id]
+  }
+
+  private_service_connection {
+    name                           = "peconnection-service-bus"
+    private_connection_resource_id = azurerm_servicebus_namespace.servicebus_namespace.id
+    is_manual_connection           = false
+    subresource_names              = ["namespace"]
+  }
+}

--- a/infra/dev/shared/terraform/modules/service-bus/outputs.tf
+++ b/infra/dev/shared/terraform/modules/service-bus/outputs.tf
@@ -1,0 +1,16 @@
+output "namespace_name" {
+  value = azurerm_servicebus_namespace.servicebus_namespace.name
+}
+
+output "servicebus_namespace_primary_connection_string" {
+  value = azurerm_servicebus_namespace.servicebus_namespace.default_primary_connection_string
+}
+
+output "queue_email_request_name" {
+  value = azurerm_servicebus_queue.email_request_queue.name
+}
+
+output "queue_email_response_name" {
+  value = azurerm_servicebus_queue.email_response_queue.name
+}
+

--- a/infra/dev/shared/terraform/modules/service-bus/variables.tf
+++ b/infra/dev/shared/terraform/modules/service-bus/variables.tf
@@ -1,0 +1,40 @@
+variable "resource_group" {
+  type        = string
+  description = "The resource group"
+}
+
+variable "environment" {
+  type        = string
+  description = "The environment (dev, test, prod...)"
+  default     = "dev"
+}
+
+variable "location" {
+  type        = string
+  description = "The Azure region where all resources in this example should be created"
+}
+
+variable "application_name" {
+  type        = string
+  description = "The name of your application"
+}
+
+variable "private_endpoint_vnet_id" {
+  type        = string
+  description = "The ID of the VNet where the private endpoint should be created"
+}
+
+variable "private_endpoint_subnet_id" {
+  type        = string
+  description = "The ID of the subnet where the private endpoint should be created"
+}
+
+variable "web_application_principal_id" {
+  type        = string
+  description = "The principal id of the identity of the entra application"
+}
+
+variable "container_app_identity_principal_id" {
+  type        = string
+  description = "The principal id of the identity of the container app"
+}

--- a/infra/dev/shared/terraform/modules/service-bus/variables.tf
+++ b/infra/dev/shared/terraform/modules/service-bus/variables.tf
@@ -19,14 +19,16 @@ variable "application_name" {
   description = "The name of your application"
 }
 
-variable "private_endpoint_vnet_id" {
+variable "spoke_vnet_id" {
   type        = string
-  description = "The ID of the VNet where the private endpoint should be created"
+  description = "The ID of the spoke VNET"
+  default     = null
 }
 
 variable "private_endpoint_subnet_id" {
   type        = string
   description = "The ID of the subnet where the private endpoint should be created"
+  default     = null
 }
 
 variable "web_application_principal_id" {
@@ -37,4 +39,10 @@ variable "web_application_principal_id" {
 variable "container_app_identity_principal_id" {
   type        = string
   description = "The principal id of the identity of the container app"
+}
+
+variable "capacity" {
+  type        = number
+  description = "The capacity of the Service Bus namespace prod instance"
+  default     = 1
 }


### PR DESCRIPTION
- Created Terraform modules for Service Bus, Container Apps and Container Registry that support the different deployment options between development and production

**For the ACA module, Terraform doesn't allow you to have a defined value for zone redundancy (true or false) in the Azure Container Apps Environment without also defining the infrastructure_subnet_id with a valid value. Because of this, I have two instances of the ACA environment, dev and prod. I used count to deploy one or the other based on the environment variable and added logic to the other resources to use whichever ACA environment id matches the environment variable. 